### PR TITLE
feat: bootstrap Vyral expo monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-store
+.expo
+.expo-shared
+*.DS_Store
+.env*
+.vscode
+.idea

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Vyral Monorepo
+
+Vyral is the flagship experience inside the future V’erse suite. This monorepo hosts a TypeScript-first Expo application with modular architecture so each module can graduate into its own mini-app.
+
+## Tech Stack
+- Expo 50 with Expo Router
+- React Native (iOS, Android, Web)
+- TypeScript (strict)
+- Zustand + React Query
+- Supabase (auth, database, storage)
+- NativeWind (Tailwind CSS for RN)
+- Neon glass cyber theme powered by Expo Linear Gradient & BlurView
+- Zod validation
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   pnpm install
+   ```
+2. **Start the Expo app**
+   ```bash
+   cd vyral
+   npx expo start
+   ```
+3. Use the QR code or platform specific commands from the Expo CLI to launch iOS, Android, or Web.
+
+### Environment Variables
+
+Create a `.env` file (or configure Expo secrets) with your Supabase project keys:
+
+```
+EXPO_PUBLIC_SUPABASE_URL=your-url
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+```
+
+### Database
+
+Run the provided SQL to bootstrap the Supabase backend.
+
+```bash
+supabase db push --file supabase/schema.sql
+supabase db push --file supabase/seed.sql
+```
+
+## Project Structure
+
+```
+/vyral
+  app/            # Expo Router routes for each V’erse module
+  components/     # Shared UI primitives (neon glass cards, buttons, etc.)
+  lib/            # Supabase client, React Query configuration, bootstrap hooks
+  store/          # Zustand stores
+  theme/          # Theme tokens and providers
+  tailwind.config.js
+supabase/         # Database schema & seeds
+```
+
+Each module (Kor, Stryke, Skrybe, Zone, Lyfe, Tree, Board, Shop, Vyra) is encapsulated so it can later evolve into a standalone micro-app under the V’erse umbrella.
+
+## Linting & Type Checking
+
+From the repo root:
+
+```bash
+pnpm lint
+pnpm typecheck
+```
+
+## Credits
+
+Crafted with luminescent love for the Vyral launch.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "vyral-one",
+  "private": true,
+  "version": "1.0.0",
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "lint": "pnpm --filter vyral lint",
+    "typecheck": "pnpm --filter vyral typecheck",
+    "start": "pnpm --filter vyral start"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "vyral"

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,64 @@
+-- Schema for Vyral Supabase backend
+create extension if not exists "uuid-ossp";
+
+create table if not exists users (
+  id uuid primary key default uuid_generate_v4(),
+  username text unique not null,
+  email text unique not null,
+  avatar_url text,
+  xp int default 0,
+  created_at timestamptz default now()
+);
+
+create table if not exists posts (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  content text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists challenges (
+  id uuid primary key default uuid_generate_v4(),
+  title text not null,
+  description text,
+  xp_reward int default 0,
+  created_at timestamptz default now()
+);
+
+create table if not exists streaks (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  count int default 0,
+  last_checked date default current_date
+);
+
+create table if not exists entries (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  content text,
+  created_at timestamptz default now()
+);
+
+create table if not exists habits (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  title text,
+  value int,
+  created_at timestamptz default now()
+);
+
+create table if not exists tasks (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  title text,
+  status text default 'todo',
+  created_at timestamptz default now()
+);
+
+create table if not exists customizations (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  theme text,
+  avatar_url text,
+  created_at timestamptz default now()
+);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,13 @@
+insert into users (username, email, avatar_url)
+values ('gary', 'gary@example.com', 'https://i.pravatar.cc/150?img=1')
+on conflict (email) do nothing;
+
+insert into challenges (title, description, xp_reward) values
+  ('7-Day Focus Streak', 'Stay focused every day for a week.', 100),
+  ('Daily Run', 'Track your run each morning.', 200)
+on conflict (title) do nothing;
+
+insert into tasks (user_id, title, status)
+select id, 'Finish first VybeTree goal', 'todo'
+from users
+where username = 'gary';

--- a/vyral/app.config.ts
+++ b/vyral/app.config.ts
@@ -1,0 +1,45 @@
+import { ExpoConfig } from "expo/config";
+
+const defineConfig = (): ExpoConfig => ({
+  name: "Vyral",
+  slug: "vyral",
+  scheme: "vyral",
+  version: "1.0.0",
+  orientation: "portrait",
+  icon: "./assets/icon.png",
+  userInterfaceStyle: "dark",
+  splash: {
+    image: "./assets/splash.png",
+    backgroundColor: "#000000"
+  },
+  assetBundlePatterns: ["**/*"],
+  experiments: {
+    typedRoutes: true
+  },
+  plugins: [
+    "expo-router",
+    ["nativewind/babel", { "isCJS": true }]
+  ],
+  extra: {
+    supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL ?? "",
+    supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? ""
+  },
+  updates: {
+    fallbackToCacheTimeout: 0
+  },
+  ios: {
+    supportsTablet: true
+  },
+  android: {
+    adaptiveIcon: {
+      foregroundImage: "./assets/adaptive-icon.png",
+      backgroundColor: "#000000"
+    }
+  },
+  web: {
+    bundler: "metro",
+    output: "static"
+  }
+});
+
+export default defineConfig;

--- a/vyral/app/_layout.tsx
+++ b/vyral/app/_layout.tsx
@@ -1,0 +1,57 @@
+import { Stack, SplashScreen } from "expo-router";
+import React, { useEffect } from "react";
+import { ThemeProvider } from "@/theme/ThemeProvider";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "@/lib/queryClient";
+import { SupabaseProvider, useSupabase } from "@/lib/supabase";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { StatusBar } from "expo-status-bar";
+import { useUserBootstrap } from "@/lib/useUserBootstrap";
+
+SplashScreen.preventAutoHideAsync().catch(() => {
+  /* ignore */
+});
+
+const RootProviders: React.FC<React.PropsWithChildren> = ({ children }) => {
+  useUserBootstrap();
+  return (
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  );
+};
+
+const RootLayoutInner: React.FC = () => {
+  const { loading } = useSupabase();
+
+  useEffect(() => {
+    if (!loading) {
+      SplashScreen.hideAsync().catch(() => undefined);
+    }
+  }, [loading]);
+
+  return (
+    <RootProviders>
+      <StatusBar style="light" />
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: "transparent" },
+          animation: "fade"
+        }}
+      />
+    </RootProviders>
+  );
+};
+
+const RootLayout: React.FC = () => {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SupabaseProvider>
+        <RootLayoutInner />
+      </SupabaseProvider>
+    </GestureHandlerRootView>
+  );
+};
+
+export default RootLayout;

--- a/vyral/app/auth/login.tsx
+++ b/vyral/app/auth/login.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { View, Text, Alert } from "react-native";
+import { useRouter } from "expo-router";
+import { Input } from "@/components/Input";
+import { Button } from "@/components/Button";
+import { useSupabase } from "@/lib/supabase";
+import { z } from "zod";
+import { colors } from "@/theme/tokens";
+import { FontAwesome } from "@expo/vector-icons";
+
+const loginSchema = z.object({
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(6, "Minimum 6 characters")
+});
+
+type LoginForm = z.infer<typeof loginSchema>;
+
+const LoginScreen: React.FC = () => {
+  const router = useRouter();
+  const { client } = useSupabase();
+  const [form, setForm] = useState<LoginForm>({ email: "", password: "" });
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async () => {
+    const result = loginSchema.safeParse(form);
+    if (!result.success) {
+      setError(result.error.errors[0]?.message ?? "Invalid input");
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    const { error: signInError } = await client.auth.signInWithPassword({
+      email: form.email,
+      password: form.password
+    });
+    setLoading(false);
+    if (signInError) {
+      Alert.alert("Login failed", signInError.message);
+    } else {
+      router.replace("/kor");
+    }
+  };
+
+  const signInWithProvider = async (provider: "google" | "apple") => {
+    const { error: authError } = await client.auth.signInWithOAuth({ provider });
+    if (authError) {
+      Alert.alert("OAuth Error", authError.message);
+    }
+  };
+
+  return (
+    <View className="flex-1 justify-center px-8">
+      <Text className="mb-2 text-4xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Welcome back
+      </Text>
+      <Text className="mb-8 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Log in to sync your Vyral Kor.
+      </Text>
+      <Input
+        label="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={form.email}
+        onChangeText={(email) => setForm((prev) => ({ ...prev, email }))}
+      />
+      <Input
+        label="Password"
+        secureTextEntry
+        value={form.password}
+        onChangeText={(password) => setForm((prev) => ({ ...prev, password }))}
+        error={error ?? undefined}
+      />
+      <Button label={loading ? "Signing in..." : "Login"} onPress={onSubmit} disabled={loading} />
+      <Text className="my-6 text-center text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+        or continue with
+      </Text>
+      <View className="flex-row justify-center">
+        <View style={{ marginHorizontal: 8 }}>
+          <Button
+            label="Google"
+            onPress={() => signInWithProvider("google")}
+            accentColor={colors.neon.blue}
+            icon={<FontAwesome name="google" size={18} color="#0a0f1e" />}
+          />
+        </View>
+        <View style={{ marginHorizontal: 8 }}>
+          <Button
+            label="Apple"
+            onPress={() => signInWithProvider("apple")}
+            accentColor={colors.neon.purple}
+            icon={<FontAwesome name="apple" size={18} color="#0a0f1e" />}
+          />
+        </View>
+      </View>
+      <Text
+        className="mt-10 text-center text-sm text-white/60"
+        onPress={() => router.push("/auth/signup")}
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        Need an account? Sign up
+      </Text>
+    </View>
+  );
+};
+
+export default LoginScreen;

--- a/vyral/app/auth/signup.tsx
+++ b/vyral/app/auth/signup.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from "react";
+import { Alert, View, Text } from "react-native";
+import { useRouter } from "expo-router";
+import { Input } from "@/components/Input";
+import { Button } from "@/components/Button";
+import { useSupabase } from "@/lib/supabase";
+import { z } from "zod";
+
+const signupSchema = z
+  .object({
+    email: z.string().email("Enter a valid email"),
+    password: z.string().min(6, "Minimum 6 characters"),
+    username: z.string().min(2, "Username required")
+  })
+  .refine((values) => !values.username.includes(" "), {
+    path: ["username"],
+    message: "No spaces allowed"
+  });
+
+type SignUpForm = z.infer<typeof signupSchema>;
+
+const SignupScreen: React.FC = () => {
+  const router = useRouter();
+  const { client } = useSupabase();
+  const [form, setForm] = useState<SignUpForm>({ email: "", password: "", username: "" });
+  const [errors, setErrors] = useState<Partial<Record<keyof SignUpForm, string>>>({});
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async () => {
+    const result = signupSchema.safeParse(form);
+    if (!result.success) {
+      const fieldError = result.error.issues[0];
+      setErrors({ [fieldError.path[0] as keyof SignUpForm]: fieldError.message });
+      return;
+    }
+    setErrors({});
+    setLoading(true);
+    const { data, error } = await client.auth.signUp({
+      email: form.email,
+      password: form.password,
+      options: {
+        data: { username: form.username }
+      }
+    });
+    setLoading(false);
+
+    if (error) {
+      Alert.alert("Sign up failed", error.message);
+      return;
+    }
+
+    if (data.session) {
+      const { error: profileError } = await client.from("users").upsert({
+        id: data.user?.id,
+        email: form.email,
+        username: form.username
+      });
+      if (profileError) {
+        Alert.alert("Profile error", profileError.message);
+      }
+      router.replace("/kor");
+    } else {
+      Alert.alert("Check your email", "Confirm your email address to continue.");
+    }
+  };
+
+  return (
+    <View className="flex-1 justify-center px-8">
+      <Text className="mb-2 text-4xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Create your Kor
+      </Text>
+      <Text className="mb-8 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Assemble your Vyral identity.
+      </Text>
+      <Input
+        label="Username"
+        value={form.username}
+        onChangeText={(username) => setForm((prev) => ({ ...prev, username }))}
+        error={errors.username}
+      />
+      <Input
+        label="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={form.email}
+        onChangeText={(email) => setForm((prev) => ({ ...prev, email }))}
+        error={errors.email}
+      />
+      <Input
+        label="Password"
+        secureTextEntry
+        value={form.password}
+        onChangeText={(password) => setForm((prev) => ({ ...prev, password }))}
+        error={errors.password}
+      />
+      <Button label={loading ? "Creating..." : "Sign Up"} onPress={onSubmit} disabled={loading} />
+      <Text
+        className="mt-10 text-center text-sm text-white/60"
+        onPress={() => router.push("/auth/login")}
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        Already have an account? Log in
+      </Text>
+    </View>
+  );
+};
+
+export default SignupScreen;

--- a/vyral/app/board/index.tsx
+++ b/vyral/app/board/index.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { View, Text, ScrollView, Alert } from "react-native";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "@/components/Card";
+import { Button } from "@/components/Button";
+import { Input } from "@/components/Input";
+import { moduleAccents } from "@/theme/tokens";
+
+const columns = [
+  { key: "todo", title: "To Do" },
+  { key: "doing", title: "Doing" },
+  { key: "done", title: "Done" }
+] as const;
+
+type ColumnKey = (typeof columns)[number]["key"];
+
+const BoardScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+  const [taskTitle, setTaskTitle] = useState("");
+
+  const tasksQuery = useQuery({
+    queryKey: ["tasks", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("tasks")
+        .select("id, title, status, created_at")
+        .eq("user_id", session!.user.id)
+        .order("created_at", { ascending: true });
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const createTask = useMutation({
+    mutationFn: async () => {
+      if (!session) throw new Error("Not authenticated");
+      if (!taskTitle.trim()) throw new Error("Give it a title");
+      const { error } = await client
+        .from("tasks")
+        .insert({ user_id: session.user.id, title: taskTitle.trim(), status: "todo" });
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      setTaskTitle("");
+      await queryClient.invalidateQueries({ queryKey: ["tasks", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to create", error.message)
+  });
+
+  const moveTask = useMutation({
+    mutationFn: async ({ id, status }: { id: string; status: ColumnKey }) => {
+      const { error } = await client.from("tasks").update({ status }).eq("id", id);
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["tasks", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to move task", error.message)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to pilot your Board.
+        </Text>
+      </View>
+    );
+  }
+
+  const tasksByColumn: Record<ColumnKey, typeof tasksQuery.data> = {
+    todo: tasksQuery.data?.filter((task) => task.status === "todo") ?? [],
+    doing: tasksQuery.data?.filter((task) => task.status === "doing") ?? [],
+    done: tasksQuery.data?.filter((task) => task.status === "done") ?? []
+  };
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 160 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Board your missions
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Flow between lanes with swift neon transitions.
+      </Text>
+      <Card accentColor={moduleAccents.board} className="mt-6 p-4">
+        <Text className="mb-3 text-sm uppercase text-white/60" style={{ fontFamily: "Inter_600SemiBold" }}>
+          Add task
+        </Text>
+        <Input label="Title" value={taskTitle} onChangeText={setTaskTitle} />
+        <Button
+          label={createTask.isPending ? "Adding..." : "Add to board"}
+          onPress={() => createTask.mutate()}
+          accentColor={moduleAccents.board}
+        />
+      </Card>
+      <View className="mt-10 flex-row" style={{ marginHorizontal: -8 }}>
+        {columns.map((column) => (
+          <View key={column.key} style={{ flex: 1, marginHorizontal: 8 }}>
+            <Text className="mb-3 text-center text-sm uppercase text-white/60" style={{ fontFamily: "Inter_600SemiBold" }}>
+              {column.title}
+            </Text>
+            <View>
+              {tasksByColumn[column.key].map((task) => (
+                <Card key={task.id} accentColor={moduleAccents.board} className="mb-4 p-4">
+                  <Text className="text-base text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+                    {task.title}
+                  </Text>
+                  <Text className="mt-2 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+                    {new Date(task.created_at).toLocaleString()}
+                  </Text>
+                  <View className="mt-3 flex-row" style={{ marginHorizontal: -6 }}>
+                    {columns
+                      .filter((col) => col.key !== column.key)
+                      .map((target) => (
+                        <View key={target.key} style={{ flex: 1, marginHorizontal: 6 }}>
+                          <Button
+                            label={target.title}
+                            onPress={() => moveTask.mutate({ id: task.id, status: target.key })}
+                            accentColor={moduleAccents.board}
+                            variant="secondary"
+                          />
+                        </View>
+                      ))}
+                  </View>
+                </Card>
+              ))}
+            </View>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default BoardScreen;

--- a/vyral/app/index.tsx
+++ b/vyral/app/index.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from "react";
+import { View, Text, Image } from "react-native";
+import { Link, useRouter } from "expo-router";
+import { Button } from "@/components/Button";
+import { colors } from "@/theme/tokens";
+import { useSupabase } from "@/lib/supabase";
+
+const OnboardingScreen: React.FC = () => {
+  const router = useRouter();
+  const { session } = useSupabase();
+
+  useEffect(() => {
+    if (session) {
+      router.replace("/kor");
+    }
+  }, [router, session]);
+
+  return (
+    <View className="flex-1 items-center justify-center px-8">
+      <View className="mb-12 items-center">
+        <Image
+          source={{ uri: "https://i.imgur.com/8Km9tLL.png" }}
+          style={{ width: 120, height: 120, marginBottom: 24, borderRadius: 60 }}
+        />
+        <Text className="text-4xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+          Vyral
+        </Text>
+        <Text
+          className="mt-4 text-center text-lg text-white/70"
+          style={{ fontFamily: "Inter_400Regular" }}
+        >
+          Enter the V’erse and amplify your flow.
+        </Text>
+      </View>
+      <View className="w-full" style={{ rowGap: 16 }}>
+        <Button
+          label="Login"
+          onPress={() => router.push("/auth/login")}
+          accentColor={colors.neon.blue}
+        />
+        <Button
+          label="Create Account"
+          onPress={() => router.push("/auth/signup")}
+          accentColor={colors.neon.purple}
+        />
+      </View>
+      <Link
+        href="/auth/login"
+        className="mt-10 text-sm text-white/60"
+        style={{ fontFamily: "Inter_400Regular" }}
+      >
+        Continue with existing session
+      </Link>
+    </View>
+  );
+};
+
+export default OnboardingScreen;

--- a/vyral/app/kor/index.tsx
+++ b/vyral/app/kor/index.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View, Text, ScrollView, Pressable } from "react-native";
+import { useUserStore } from "@/store/useUserStore";
+import { Avatar } from "@/components/Avatar";
+import { ProgressRing } from "@/components/Progress";
+import { colors, moduleAccents } from "@/theme/tokens";
+import { Link } from "expo-router";
+import { Card } from "@/components/Card";
+
+const KorScreen: React.FC = () => {
+  const profile = useUserStore((state) => state.profile);
+  const xp = profile?.xp ?? 0;
+  const level = Math.floor(xp / 1000) + 1;
+  const progress = Math.min((xp % 1000) / 1000, 1);
+
+  const modules = [
+    { key: "stryke", title: "Stryke", subtitle: "Challenges & streaks" },
+    { key: "skrybe", title: "Skrybe", subtitle: "AI infused journaling" },
+    { key: "zone", title: "Zone", subtitle: "Flow focus timer" },
+    { key: "lyfe", title: "Lyfe", subtitle: "Lifestyle rituals" },
+    { key: "tree", title: "Tree", subtitle: "Goal map" },
+    { key: "board", title: "Board", subtitle: "Productivity board" },
+    { key: "shop", title: "Shop", subtitle: "Rewards" },
+    { key: "vyra", title: "Vyra", subtitle: "Avatar & theme" }
+  ] as const;
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 120 }}>
+      <Text className="text-sm uppercase text-white/60" style={{ fontFamily: "Inter_600SemiBold" }}>
+        Kor nucleus
+      </Text>
+      <Text className="mt-1 text-4xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Hey {profile?.username ?? "Explorer"}
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Level {level} • {xp} XP
+      </Text>
+      <View className="mt-8 items-center">
+        <ProgressRing progress={progress} label="Next level" accentColor={colors.neon.blue} />
+        <View className="-mt-36">
+          <Avatar uri={profile?.avatar_url ?? undefined} size={120} />
+        </View>
+      </View>
+      <Text className="mt-12 text-lg text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+        Modules
+      </Text>
+      <View
+        className="mt-4 flex flex-wrap flex-row justify-between"
+        style={{ rowGap: 16, columnGap: 16 }}
+      >
+        {modules.map((module) => (
+          <Link key={module.key} href={`/${module.key}`} asChild>
+            <Pressable
+              className="w-[48%]"
+              style={{ shadowColor: moduleAccents[module.key], shadowOpacity: 0.3, shadowRadius: 12 }}
+            >
+              <Card accentColor={moduleAccents[module.key]} className="p-4">
+                <Text className="text-xl text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+                  {module.title}
+                </Text>
+                <Text className="mt-2 text-xs text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+                  {module.subtitle}
+                </Text>
+              </Card>
+            </Pressable>
+          </Link>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default KorScreen;

--- a/vyral/app/lyfe/index.tsx
+++ b/vyral/app/lyfe/index.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import { View, Text, ScrollView, Modal, Alert } from "react-native";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "@/components/Card";
+import { Button } from "@/components/Button";
+import { Input } from "@/components/Input";
+import { FAB } from "@/components/FAB";
+import { moduleAccents } from "@/theme/tokens";
+
+const LyfeScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+  const [modalVisible, setModalVisible] = useState(false);
+  const [title, setTitle] = useState("");
+
+  const habitsQuery = useQuery({
+    queryKey: ["habits", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("habits")
+        .select("id, title, value, created_at")
+        .eq("user_id", session!.user.id)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const createHabit = useMutation({
+    mutationFn: async () => {
+      if (!session) throw new Error("Not authenticated");
+      if (!title.trim()) throw new Error("Name your habit");
+      const { error } = await client
+        .from("habits")
+        .insert({ user_id: session.user.id, title: title.trim(), value: 1 });
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      setTitle("");
+      setModalVisible(false);
+      await queryClient.invalidateQueries({ queryKey: ["habits", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to log", error.message)
+  });
+
+  const incrementHabit = useMutation({
+    mutationFn: async (habitId: string) => {
+      const habit = habitsQuery.data?.find((item) => item.id === habitId);
+      const { error } = await client
+        .from("habits")
+        .update({ value: (habit?.value ?? 0) + 1 })
+        .eq("id", habitId);
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["habits", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to update", error.message)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to sync your Lyfe rituals.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1">
+      <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 160 }}>
+        <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+          Calibrate your Lyfe
+        </Text>
+        <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Track habits and moods in luminous cards.
+        </Text>
+        <View className="mt-8" style={{ rowGap: 16 }}>
+          {habitsQuery.data?.map((habit) => (
+            <Card key={habit.id} accentColor={moduleAccents.lyfe} className="p-4">
+              <Text className="text-xl text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+                {habit.title}
+              </Text>
+              <Text className="mt-2 text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+                Logged {habit.value ?? 0} times
+              </Text>
+              <Button
+                label={incrementHabit.isPending ? "Logging..." : "Log again"}
+                onPress={() => incrementHabit.mutate(habit.id)}
+                accentColor={moduleAccents.lyfe}
+              />
+            </Card>
+          ))}
+        </View>
+      </ScrollView>
+      <FAB label="New habit" onPress={() => setModalVisible(true)} accentColor={moduleAccents.lyfe} />
+      <Modal visible={modalVisible} transparent animationType="fade">
+        <View className="flex-1 items-center justify-center bg-black/70 px-6">
+          <Card accentColor={moduleAccents.lyfe} className="w-full p-6">
+            <Text className="mb-4 text-lg text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+              Create habit
+            </Text>
+            <Input label="Title" value={title} onChangeText={setTitle} />
+            <Button
+              label={createHabit.isPending ? "Saving..." : "Save"}
+              onPress={() => createHabit.mutate()}
+              accentColor={moduleAccents.lyfe}
+            />
+            <Button label="Cancel" onPress={() => setModalVisible(false)} variant="secondary" />
+          </Card>
+        </View>
+      </Modal>
+    </View>
+  );
+};
+
+export default LyfeScreen;

--- a/vyral/app/shop/index.tsx
+++ b/vyral/app/shop/index.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { View, Text, ScrollView, Alert } from "react-native";
+import { Card } from "@/components/Card";
+import { Button } from "@/components/Button";
+import { moduleAccents } from "@/theme/tokens";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+
+const shopItems = [
+  { id: "nebula", title: "Nebula Trail", description: "Animated star trail theme", cost: 400 },
+  { id: "cyber", title: "Cyber Bloom", description: "Neon petals swirl aura", cost: 250 },
+  { id: "aurora", title: "Aurora Drift", description: "Dynamic teal gradient", cost: 150 }
+];
+
+const ShopScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+
+  const customizationQuery = useQuery({
+    queryKey: ["customizations", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("customizations")
+        .select("id, theme, avatar_url")
+        .eq("user_id", session!.user.id)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const purchaseMutation = useMutation({
+    mutationFn: async (theme: string) => {
+      if (!session) throw new Error("Login required");
+      const { error } = await client
+        .from("customizations")
+        .upsert({ user_id: session.user.id, theme })
+        .select();
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      Alert.alert("Unlocked!", "Your new vibe is active in Vyra.");
+      await queryClient.invalidateQueries({ queryKey: ["customizations", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to purchase", error.message)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to access the Vyral shop.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 140 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Stock your arsenal
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Spend points to unlock neon cosmetics.
+      </Text>
+      <View className="mt-8" style={{ rowGap: 16 }}>
+        {shopItems.map((item) => {
+          const isActive = customizationQuery.data?.theme === item.id;
+          return (
+            <Card key={item.id} accentColor={moduleAccents.shop} className="p-4">
+              <Text className="text-xl text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+                {item.title}
+              </Text>
+              <Text className="mt-2 text-sm text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+                {item.description}
+              </Text>
+              <Text className="mt-3 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+                {item.cost} pts
+              </Text>
+              <Button
+                label={isActive ? "Equipped" : "Unlock"}
+                onPress={() => purchaseMutation.mutate(item.id)}
+                accentColor={moduleAccents.shop}
+                disabled={isActive || purchaseMutation.isPending}
+              />
+            </Card>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default ShopScreen;

--- a/vyral/app/skrybe/index.tsx
+++ b/vyral/app/skrybe/index.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import { View, Text, ScrollView, TextInput, Alert } from "react-native";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "@/components/Card";
+import { Button } from "@/components/Button";
+import { moduleAccents } from "@/theme/tokens";
+
+const SkrybeScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("");
+
+  const entriesQuery = useQuery({
+    queryKey: ["entries", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("entries")
+        .select("id, content, created_at")
+        .eq("user_id", session!.user.id)
+        .order("created_at", { ascending: false });
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const createEntry = useMutation({
+    mutationFn: async () => {
+      if (!session) throw new Error("Not authenticated");
+      if (!content.trim()) {
+        throw new Error("Write something first");
+      }
+      const { error } = await client
+        .from("entries")
+        .insert({ user_id: session.user.id, content: content.trim() });
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      setContent("");
+      await queryClient.invalidateQueries({ queryKey: ["entries", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to save", error.message)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to start chronicling your Skrybe.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 160 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Skrybe your flow
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Capture thoughts, ideas, and future AI prompts.
+      </Text>
+      <Card accentColor={moduleAccents.skrybe} className="mt-6 p-4">
+        <Text className="mb-3 text-sm uppercase text-white/50" style={{ fontFamily: "Inter_600SemiBold" }}>
+          New entry
+        </Text>
+        <TextInput
+          multiline
+          value={content}
+          onChangeText={setContent}
+          placeholder="Stream your consciousness..."
+          placeholderTextColor="rgba(255,255,255,0.5)"
+          style={{
+            minHeight: 150,
+            fontFamily: "Inter_400Regular",
+            color: "#fff",
+            textAlignVertical: "top"
+          }}
+        />
+        <Button
+          label={createEntry.isPending ? "Saving..." : "Save entry"}
+          onPress={() => createEntry.mutate()}
+          accentColor={moduleAccents.skrybe}
+          disabled={createEntry.isPending}
+        />
+        <Text className="mt-4 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+          AI synthesis arriving soon.
+        </Text>
+      </Card>
+      <View className="mt-10" style={{ rowGap: 16 }}>
+        {entriesQuery.data?.map((entry) => (
+          <Card key={entry.id} accentColor={moduleAccents.skrybe} className="p-4">
+            <Text className="text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+              {new Date(entry.created_at).toLocaleString()}
+            </Text>
+            <Text className="mt-2 text-base text-white" style={{ fontFamily: "Inter_400Regular" }}>
+              {entry.content}
+            </Text>
+          </Card>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default SkrybeScreen;

--- a/vyral/app/stryke/index.tsx
+++ b/vyral/app/stryke/index.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { View, Text, ScrollView, Alert, Pressable } from "react-native";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useSupabase } from "@/lib/supabase";
+import { Card } from "@/components/Card";
+import { moduleAccents } from "@/theme/tokens";
+import { useUserStore } from "@/store/useUserStore";
+
+const StrykeScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const profile = useUserStore((state) => state.profile);
+  const queryClient = useQueryClient();
+
+  const { data: challenges } = useQuery({
+    queryKey: ["challenges"],
+    queryFn: async () => {
+      const { data, error } = await client.from("challenges").select("*").order("created_at", { ascending: false });
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const { data: streak } = useQuery({
+    queryKey: ["streak", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("streaks")
+        .select("id, count, last_checked")
+        .eq("user_id", session!.user.id)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: async (challengeId: string) => {
+      if (!session) throw new Error("No session");
+      const { error } = await client
+        .from("streaks")
+        .upsert({ user_id: session.user.id, count: (streak?.count ?? 0) + 1 })
+        .select();
+      if (error) throw error;
+      await client
+        .from("posts")
+        .insert({ user_id: session.user.id, content: `Joined challenge ${challengeId}` });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["streak", session?.user.id] });
+      Alert.alert("Streak boosted", "You joined the mission. Stay consistent!");
+    },
+    onError: (error) => {
+      Alert.alert("Action failed", error.message);
+    }
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to blaze your Stryke challenges.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 120 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Ignite your streak
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        {profile?.username ?? "You"} • Streak {streak?.count ?? 0}
+      </Text>
+      <View className="mt-8" style={{ rowGap: 16 }}>
+        {challenges?.map((challenge) => (
+          <Card key={challenge.id} accentColor={moduleAccents.stryke} className="p-4">
+            <Text className="text-2xl text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+              {challenge.title}
+            </Text>
+            <Text className="mt-2 text-sm text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+              {challenge.description}
+            </Text>
+            <Text className="mt-2 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+              XP reward: {challenge.xp_reward}
+            </Text>
+            <Pressable
+              onPress={() => joinMutation.mutate(challenge.id)}
+              className="mt-4 self-start rounded-full border border-white/20 px-4 py-2"
+            >
+              <Text className="text-sm text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+                {joinMutation.isPending ? "Joining..." : "Join challenge"}
+              </Text>
+            </Pressable>
+          </Card>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default StrykeScreen;

--- a/vyral/app/tree/index.tsx
+++ b/vyral/app/tree/index.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { View, Text, ScrollView } from "react-native";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery } from "@tanstack/react-query";
+import { Card } from "@/components/Card";
+import { moduleAccents } from "@/theme/tokens";
+
+const levels = ["vision", "growth", "harvest"] as const;
+
+type LevelKey = (typeof levels)[number];
+
+const TreeScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+
+  const goalsQuery = useQuery({
+    queryKey: ["tree-goals", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("tasks")
+        .select("id, title, status, created_at")
+        .eq("user_id", session!.user.id)
+        .order("created_at", { ascending: true });
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to cultivate your Tree goals.
+        </Text>
+      </View>
+    );
+  }
+
+  const nodesByLevel: Record<LevelKey, typeof goalsQuery.data> = {
+    vision: goalsQuery.data?.filter((goal) => goal.status === "todo") ?? [],
+    growth: goalsQuery.data?.filter((goal) => goal.status === "doing") ?? [],
+    harvest: goalsQuery.data?.filter((goal) => goal.status === "done") ?? []
+  };
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 140 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Grow your Vyral Tree
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Visualize goals branching from intention to impact.
+      </Text>
+      <View className="mt-10" style={{ rowGap: 32 }}>
+        {levels.map((level) => (
+          <View key={level}>
+            <Text className="mb-4 text-sm uppercase text-white/60" style={{ fontFamily: "Inter_600SemiBold" }}>
+              {level}
+            </Text>
+            <View className="flex-row flex-wrap" style={{ marginHorizontal: -8 }}>
+              {nodesByLevel[level].map((node) => (
+                <View key={node.id} style={{ width: 160, marginHorizontal: 8, marginBottom: 16 }}>
+                  <Card accentColor={moduleAccents.tree} className="p-4">
+                    <Text className="text-sm text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+                      {node.title}
+                    </Text>
+                    <Text className="mt-2 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+                      {new Date(node.created_at).toLocaleDateString()}
+                    </Text>
+                  </Card>
+                </View>
+              ))}
+              {nodesByLevel[level].length === 0 ? (
+                <View style={{ width: 160, marginHorizontal: 8, marginBottom: 16 }}>
+                  <Card accentColor={moduleAccents.tree} className="items-center justify-center p-4 border-dashed border-white/20">
+                    <Text className="text-center text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+                      Plant a new goal on the Board.
+                    </Text>
+                  </Card>
+                </View>
+              ) : null}
+            </View>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default TreeScreen;

--- a/vyral/app/vyra/index.tsx
+++ b/vyral/app/vyra/index.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from "react";
+import { View, Text, ScrollView, Alert } from "react-native";
+import { useSupabase } from "@/lib/supabase";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card } from "@/components/Card";
+import { Input } from "@/components/Input";
+import { Button } from "@/components/Button";
+import { moduleAccents } from "@/theme/tokens";
+import { Avatar } from "@/components/Avatar";
+
+const themeOptions = ["nebula", "cyber", "aurora", "default"];
+
+const VyraScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+  const [avatarUrl, setAvatarUrl] = useState("");
+  const [theme, setTheme] = useState("default");
+
+  const customizationQuery = useQuery({
+    queryKey: ["customizations", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("customizations")
+        .select("id, theme, avatar_url")
+        .eq("user_id", session!.user.id)
+        .maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  useEffect(() => {
+    if (customizationQuery.data) {
+      setAvatarUrl(customizationQuery.data.avatar_url ?? "");
+      setTheme(customizationQuery.data.theme ?? "default");
+    }
+  }, [customizationQuery.data]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      if (!session) throw new Error("Login required");
+      const { error } = await client
+        .from("customizations")
+        .upsert({ user_id: session.user.id, avatar_url: avatarUrl || null, theme })
+        .select();
+      if (error) throw error;
+    },
+    onSuccess: async () => {
+      Alert.alert("Vyra updated", "Customization saved.");
+      await queryClient.invalidateQueries({ queryKey: ["customizations", session?.user.id] });
+    },
+    onError: (error) => Alert.alert("Unable to save", error.message)
+  });
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to tune your Vyra avatar.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 140 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Shape your Vyra
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Calibrate avatar and theme to mirror your energy.
+      </Text>
+      <Card accentColor={moduleAccents.vyra} className="mt-6 items-center p-6">
+        <Avatar uri={avatarUrl} size={120} />
+        <Input
+          label="Avatar URL"
+          value={avatarUrl}
+          onChangeText={setAvatarUrl}
+          placeholder="https://..."
+          autoCapitalize="none"
+        />
+        <Text className="mb-2 mt-4 self-start text-xs uppercase text-white/60" style={{ fontFamily: "Inter_600SemiBold" }}>
+          Theme
+        </Text>
+        <View className="w-full flex-row flex-wrap" style={{ marginHorizontal: -8 }}>
+          {themeOptions.map((option) => (
+            <View key={option} style={{ width: "50%", paddingHorizontal: 8, marginBottom: 12 }}>
+              <Button
+                label={option === "default" ? "Default" : option}
+                onPress={() => setTheme(option)}
+                accentColor={option === theme ? moduleAccents.vyra : "rgba(255,255,255,0.3)"}
+                variant={option === theme ? "primary" : "secondary"}
+              />
+            </View>
+          ))}
+        </View>
+        <Button
+          className="mt-6"
+          label={saveMutation.isPending ? "Saving..." : "Save changes"}
+          onPress={() => saveMutation.mutate()}
+          accentColor={moduleAccents.vyra}
+        />
+      </Card>
+    </ScrollView>
+  );
+};
+
+export default VyraScreen;

--- a/vyral/app/zone/index.tsx
+++ b/vyral/app/zone/index.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { View, Text, ScrollView } from "react-native";
+import { Button } from "@/components/Button";
+import { ProgressRing } from "@/components/Progress";
+import { moduleAccents } from "@/theme/tokens";
+
+const focusDurations = [15, 25, 45];
+
+const ZoneScreen: React.FC = () => {
+  const [selectedDuration, setSelectedDuration] = useState(25);
+  const [secondsLeft, setSecondsLeft] = useState(selectedDuration * 60);
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (!active) return;
+    const interval = setInterval(() => {
+      setSecondsLeft((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [active]);
+
+  useEffect(() => {
+    if (secondsLeft === 0 && active) {
+      setActive(false);
+    }
+  }, [secondsLeft, active]);
+
+  const progress = useMemo(() => secondsLeft / (selectedDuration * 60), [secondsLeft, selectedDuration]);
+
+  const toggleTimer = () => {
+    if (secondsLeft === 0) {
+      setSecondsLeft(selectedDuration * 60);
+    }
+    setActive((prev) => !prev);
+  };
+
+  const resetTimer = () => {
+    setActive(false);
+    setSecondsLeft(selectedDuration * 60);
+  };
+
+  const onSelect = (minutes: number) => {
+    setSelectedDuration(minutes);
+    setSecondsLeft(minutes * 60);
+    setActive(false);
+  };
+
+  const minutes = Math.floor(secondsLeft / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = Math.floor(secondsLeft % 60)
+    .toString()
+    .padStart(2, "0");
+
+  return (
+    <ScrollView className="flex-1 px-6 pt-16" contentContainerStyle={{ paddingBottom: 120 }}>
+      <Text className="text-3xl text-white" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+        Enter the Zone
+      </Text>
+      <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+        Pulse into deep focus with neon ambience.
+      </Text>
+      <View className="mt-10 items-center">
+        <ProgressRing progress={progress} label={`${minutes}:${seconds}`} accentColor={moduleAccents.zone} />
+      </View>
+      <View className="mt-12 flex-row justify-between" style={{ marginHorizontal: -6 }}>
+        {focusDurations.map((duration) => (
+          <View key={duration} style={{ flex: 1, marginHorizontal: 6 }}>
+            <Button
+              label={`${duration}m`}
+              onPress={() => onSelect(duration)}
+              accentColor={duration === selectedDuration ? moduleAccents.zone : "rgba(255,255,255,0.3)"}
+              variant={duration === selectedDuration ? "primary" : "secondary"}
+            />
+          </View>
+        ))}
+      </View>
+      <View className="mt-12">
+        <View style={{ marginBottom: 16 }}>
+          <Button
+            label={active ? "Pause" : "Start"}
+            onPress={toggleTimer}
+            accentColor={moduleAccents.zone}
+          />
+        </View>
+        <Button label="Reset" onPress={resetTimer} variant="secondary" />
+      </View>
+    </ScrollView>
+  );
+};
+
+export default ZoneScreen;

--- a/vyral/assets/README.md
+++ b/vyral/assets/README.md
@@ -1,0 +1,3 @@
+# Vyral Assets
+
+Add generated icons, splash screens, and marketing art here.

--- a/vyral/babel.config.js
+++ b/vyral/babel.config.js
@@ -1,0 +1,21 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      require.resolve("expo-router/babel"),
+      [
+        "module-resolver",
+        {
+          alias: {
+            "@/components": "./components",
+            "@/lib": "./lib",
+            "@/store": "./store",
+            "@/theme": "./theme"
+          }
+        }
+      ],
+      "nativewind/babel"
+    ]
+  };
+};

--- a/vyral/components/Avatar.tsx
+++ b/vyral/components/Avatar.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Image, ImageProps, View } from "react-native";
+import { colors } from "@/theme/tokens";
+
+interface AvatarProps extends Omit<ImageProps, "source"> {
+  uri?: string | null;
+  size?: number;
+}
+
+export const Avatar: React.FC<AvatarProps> = ({ uri, size = 72, style, ...rest }) => {
+  return (
+    <View
+      style={{
+        width: size + 12,
+        height: size + 12,
+        borderRadius: (size + 12) / 2,
+        padding: 6,
+        backgroundColor: "rgba(0, 247, 255, 0.15)",
+        justifyContent: "center",
+        alignItems: "center",
+        shadowColor: colors.neon.blue,
+        shadowOpacity: 0.4,
+        shadowRadius: 16
+      }}
+    >
+      <Image
+        {...rest}
+        source={{
+          uri:
+            uri ??
+            "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=200&q=80"
+        }}
+        style={[
+          {
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            borderColor: "rgba(255,255,255,0.25)",
+            borderWidth: 2
+          },
+          style
+        ]}
+      />
+    </View>
+  );
+};

--- a/vyral/components/Button.tsx
+++ b/vyral/components/Button.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { Pressable, PressableProps, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { colors, timing } from "@/theme/tokens";
+import { clsx } from "clsx";
+
+type ButtonProps = {
+  label: string;
+  onPress: () => void;
+  variant?: "primary" | "secondary";
+  accentColor?: string;
+  disabled?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
+  pressableProps?: Omit<PressableProps, "onPress">;
+};
+
+export const Button: React.FC<ButtonProps> = ({
+  label,
+  onPress,
+  variant = "primary",
+  accentColor = colors.neon.blue,
+  disabled,
+  icon,
+  className,
+  pressableProps
+}) => {
+  const gradientColors =
+    variant === "primary"
+      ? [accentColor, colors.neon.purple]
+      : ["rgba(255,255,255,0.08)", "rgba(255,255,255,0.02)"];
+
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      className={clsx(
+        "overflow-hidden rounded-glass",
+        disabled ? "opacity-60" : "",
+        className
+      )}
+      style={{
+        shadowColor: accentColor,
+        shadowOpacity: 0.45,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 0 },
+        elevation: 5
+      }}
+      {...pressableProps}
+    >
+      <LinearGradient
+        colors={gradientColors}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{
+          paddingVertical: 16,
+          paddingHorizontal: 24,
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center"
+        }}
+      >
+        {icon ? <View style={{ marginRight: 12 }}>{icon}</View> : null}
+        <Text
+          className={clsx(
+            "text-center text-base font-semibold",
+            variant === "primary" ? "text-black" : "text-white"
+          )}
+          style={{
+            fontFamily: "Inter_600SemiBold",
+            letterSpacing: 0.6,
+            transitionDuration: `${timing.tap}ms`
+          }}
+        >
+          {label}
+        </Text>
+      </LinearGradient>
+    </Pressable>
+  );
+};

--- a/vyral/components/Card.tsx
+++ b/vyral/components/Card.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren } from "react";
+import { View, ViewProps } from "react-native";
+import { colors } from "@/theme/tokens";
+import { clsx } from "clsx";
+
+interface CardProps extends ViewProps {
+  accentColor?: string;
+}
+
+export const Card: React.FC<PropsWithChildren<CardProps>> = ({
+  children,
+  accentColor = colors.neon.blue,
+  className,
+  style,
+  ...rest
+}) => (
+  <View
+    {...rest}
+    className={clsx("rounded-glass border border-white/10 bg-white/5", className)}
+    style={[
+      style,
+      {
+        shadowColor: accentColor,
+        shadowOpacity: 0.3,
+        shadowRadius: 16,
+        shadowOffset: { width: 0, height: 0 },
+        backgroundColor: colors.glass
+      }
+    ]}
+  >
+    {children}
+  </View>
+);

--- a/vyral/components/FAB.tsx
+++ b/vyral/components/FAB.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Pressable, Text } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { colors } from "@/theme/tokens";
+
+interface FABProps {
+  label: string;
+  onPress: () => void;
+  icon?: React.ReactNode;
+  accentColor?: string;
+}
+
+export const FAB: React.FC<FABProps> = ({ label, onPress, icon, accentColor = colors.neon.purple }) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="absolute bottom-8 right-6 flex-row items-center overflow-hidden rounded-full"
+      style={{ shadowColor: accentColor, shadowOpacity: 0.45, shadowRadius: 20, elevation: 8 }}
+    >
+      <LinearGradient
+        colors={[accentColor, colors.neon.blue]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{ paddingVertical: 14, paddingHorizontal: 20, flexDirection: "row", alignItems: "center", gap: 8 }}
+      >
+        {icon}
+        <Text className="text-base font-semibold text-black" style={{ fontFamily: "Inter_600SemiBold" }}>
+          {label}
+        </Text>
+      </LinearGradient>
+    </Pressable>
+  );
+};

--- a/vyral/components/Input.tsx
+++ b/vyral/components/Input.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { TextInput, TextInputProps, View, Text } from "react-native";
+import { colors } from "@/theme/tokens";
+
+interface InputProps extends TextInputProps {
+  label?: string;
+  error?: string;
+}
+
+export const Input: React.FC<InputProps> = ({ label, error, style, ...rest }) => {
+  return (
+    <View className="mb-4">
+      {label ? (
+        <Text
+          className="mb-2 text-sm text-white/80"
+          style={{ fontFamily: "Inter_600SemiBold", letterSpacing: 0.4 }}
+        >
+          {label}
+        </Text>
+      ) : null}
+      <View
+        style={{
+          backgroundColor: colors.glass,
+          borderRadius: 16,
+          borderWidth: 1,
+          borderColor: "rgba(255,255,255,0.12)",
+          paddingHorizontal: 16,
+          paddingVertical: 14
+        }}
+      >
+        <TextInput
+          placeholderTextColor="rgba(248,251,255,0.5)"
+          className="text-base text-white"
+          style={[{ fontFamily: "Inter_400Regular" }, style]}
+          {...rest}
+        />
+      </View>
+      {error ? (
+        <Text className="mt-1 text-xs text-red-400" style={{ fontFamily: "Inter_400Regular" }}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+};

--- a/vyral/components/Progress.tsx
+++ b/vyral/components/Progress.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import Svg, { Circle } from "react-native-svg";
+import { View, Text } from "react-native";
+import { colors } from "@/theme/tokens";
+
+interface ProgressProps {
+  size?: number;
+  progress: number; // 0 - 1
+  label?: string;
+  accentColor?: string;
+}
+
+export const ProgressRing: React.FC<ProgressProps> = ({
+  size = 160,
+  progress,
+  label,
+  accentColor = colors.neon.blue
+}) => {
+  const strokeWidth = 12;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - progress * circumference;
+
+  return (
+    <View className="items-center justify-center">
+      <Svg width={size} height={size}>
+        <Circle
+          stroke="rgba(255,255,255,0.08)"
+          fill="transparent"
+          strokeWidth={strokeWidth}
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+        />
+        <Circle
+          stroke={accentColor}
+          fill="transparent"
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+          strokeDasharray={`${circumference} ${circumference}`}
+          strokeDashoffset={offset}
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+        />
+      </Svg>
+      <View className="absolute items-center">
+        <Text
+          className="text-3xl text-white"
+          style={{ fontFamily: "SpaceGrotesk_700Bold" }}
+        >
+          {Math.round(progress * 100)}%
+        </Text>
+        {label ? (
+          <Text className="mt-2 text-sm text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+            {label}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+};

--- a/vyral/lib/queryClient.ts
+++ b/vyral/lib/queryClient.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 30,
+      refetchOnWindowFocus: false,
+      retry: 1
+    }
+  }
+});

--- a/vyral/lib/supabase.ts
+++ b/vyral/lib/supabase.ts
@@ -1,0 +1,75 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createContext, useContext, useEffect, useState } from "react";
+import {
+  Session,
+  SupabaseClient,
+  createClient
+} from "@supabase/supabase-js";
+import Constants from "expo-constants";
+import { AppStateStatus, AppState } from "react-native";
+
+const supabaseUrl = Constants.expoConfig?.extra?.supabaseUrl ?? "";
+const supabaseAnonKey = Constants.expoConfig?.extra?.supabaseAnonKey ?? "";
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false
+  }
+});
+
+type SupabaseContextValue = {
+  client: SupabaseClient;
+  session: Session | null;
+  loading: boolean;
+};
+
+const SupabaseContext = createContext<SupabaseContextValue | undefined>(undefined);
+
+export const SupabaseProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setSession(data.session);
+      setLoading(false);
+    });
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_, newSession) => {
+      setSession(newSession);
+    });
+
+    const handleAppStateChange = (state: AppStateStatus) => {
+      if (state === "active") {
+        void supabase.auth.getSession().then(({ data }) => setSession(data.session));
+      }
+    };
+
+    const appStateSub = AppState.addEventListener("change", handleAppStateChange);
+
+    return () => {
+      mounted = false;
+      subscription.subscription.unsubscribe();
+      appStateSub.remove();
+    };
+  }, []);
+
+  return (
+    <SupabaseContext.Provider value={{ client: supabase, session, loading }}>
+      {children}
+    </SupabaseContext.Provider>
+  );
+};
+
+export const useSupabase = (): SupabaseContextValue => {
+  const value = useContext(SupabaseContext);
+  if (!value) {
+    throw new Error("useSupabase must be used inside SupabaseProvider");
+  }
+  return value;
+};

--- a/vyral/lib/useUserBootstrap.ts
+++ b/vyral/lib/useUserBootstrap.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useSupabase } from "@/lib/supabase";
+import { useUserStore } from "@/store/useUserStore";
+
+export const useUserBootstrap = (): void => {
+  const { session, client } = useSupabase();
+  const setProfile = useUserStore((state) => state.setProfile);
+
+  useEffect(() => {
+    if (!session) {
+      setProfile(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    const hydrateProfile = async () => {
+      const { data, error } = await client
+        .from("users")
+        .select("id, username, email, avatar_url, xp")
+        .eq("id", session.user.id)
+        .single();
+
+      if (isMounted && !error) {
+        setProfile(data ?? null);
+      }
+    };
+
+    void hydrateProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [client, session, setProfile]);
+};

--- a/vyral/package.json
+++ b/vyral/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "vyral",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@expo-google-fonts/inter": "^0.2.3",
+    "@expo-google-fonts/space-grotesk": "^0.2.3",
+    "@expo/vector-icons": "^14.0.2",
+    "@supabase/supabase-js": "^2.39.7",
+    "@tanstack/react-query": "^5.27.3",
+    "expo": "^50.0.17",
+    "expo-blur": "~12.7.2",
+    "expo-font": "~11.10.3",
+    "expo-linear-gradient": "~12.7.0",
+    "expo-router": "^3.4.8",
+    "expo-secure-store": "~12.7.0",
+    "expo-splash-screen": "~0.26.5",
+    "expo-status-bar": "~1.11.1",
+    "nativewind": "^4.0.23",
+    "react": "18.2.0",
+    "react-native": "0.73.6",
+    "react-native-gesture-handler": "~2.14.0",
+    "react-native-reanimated": "~3.6.2",
+    "react-native-safe-area-context": "4.8.2",
+    "react-native-screens": "~3.29.0",
+    "zod": "^3.22.4",
+    "zustand": "^4.4.7",
+    "clsx": "^2.0.0",
+    "react-native-svg": "13.14.0",
+    "@react-native-async-storage/async-storage": "1.21.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.9",
+    "@types/react": "~18.2.47",
+    "@types/react-native": "~0.73.0",
+    "babel-plugin-module-resolver": "^5.0.0",
+    "babel-preset-expo": "^10.0.1",
+    "eslint": "^8.56.0",
+    "eslint-config-universe": "^12.0.1",
+    "tailwindcss": "^3.3.6",
+    "typescript": "~5.3.3"
+  }
+}

--- a/vyral/store/useUserStore.ts
+++ b/vyral/store/useUserStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+export type UserProfile = {
+  id: string;
+  username: string;
+  email: string;
+  avatar_url?: string | null;
+  xp?: number;
+};
+
+type State = {
+  profile: UserProfile | null;
+};
+
+type Actions = {
+  setProfile: (profile: UserProfile | null) => void;
+  updateXP: (xp: number) => void;
+};
+
+export const useUserStore = create<State & Actions>((set) => ({
+  profile: null,
+  setProfile: (profile) => set({ profile }),
+  updateXP: (xp) =>
+    set((state) =>
+      state.profile ? { profile: { ...state.profile, xp } } : { profile: state.profile }
+    )
+}));

--- a/vyral/tailwind.config.js
+++ b/vyral/tailwind.config.js
@@ -1,0 +1,34 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./app/**/*.{tsx,ts}", "./components/**/*.{tsx,ts}", "./theme/**/*.{tsx,ts}", "./theme/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        heading: ['"Space Grotesk"', 'sans-serif'],
+        body: ['Inter', 'sans-serif']
+      },
+      colors: {
+        background: {
+          DEFAULT: "#000000",
+          deep: "#0a0f1e"
+        },
+        neon: {
+          blue: "#00f7ff",
+          purple: "#a020f0",
+          teal: "#00ffd1"
+        },
+        glass: "rgba(255,255,255,0.08)"
+      },
+      borderRadius: {
+        glass: "24px"
+      },
+      boxShadow: {
+        neon: "0 0 20px rgba(0, 247, 255, 0.45)"
+      },
+      transitionTimingFunction: {
+        neon: "cubic-bezier(0.4, 0, 0.2, 1)"
+      }
+    }
+  },
+  plugins: []
+};

--- a/vyral/theme/ThemeProvider.tsx
+++ b/vyral/theme/ThemeProvider.tsx
@@ -1,0 +1,34 @@
+import React, { PropsWithChildren } from "react";
+import { LinearGradient } from "expo-linear-gradient";
+import { useFonts } from "expo-font";
+import {
+  SpaceGrotesk_400Regular,
+  SpaceGrotesk_500Medium,
+  SpaceGrotesk_700Bold
+} from "@expo-google-fonts/space-grotesk";
+import { Inter_400Regular, Inter_600SemiBold } from "@expo-google-fonts/inter";
+import { View } from "react-native";
+import { colors } from "@/theme/tokens";
+import { BlurView } from "expo-blur";
+
+export const ThemeProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [fontsLoaded] = useFonts({
+    SpaceGrotesk_400Regular,
+    SpaceGrotesk_500Medium,
+    SpaceGrotesk_700Bold,
+    Inter_400Regular,
+    Inter_600SemiBold
+  });
+
+  if (!fontsLoaded) {
+    return <View style={{ flex: 1, backgroundColor: "#000" }} />;
+  }
+
+  return (
+    <LinearGradient colors={[colors.background.start, colors.background.end]} style={{ flex: 1 }}>
+      <BlurView intensity={15} tint="dark" style={{ flex: 1 }}>
+        {children}
+      </BlurView>
+    </LinearGradient>
+  );
+};

--- a/vyral/theme/tokens.ts
+++ b/vyral/theme/tokens.ts
@@ -1,0 +1,50 @@
+export const colors = {
+  background: {
+    start: "#000000",
+    end: "#0a0f1e"
+  },
+  neon: {
+    blue: "#00f7ff",
+    purple: "#a020f0",
+    teal: "#00ffd1"
+  },
+  glass: "rgba(255,255,255,0.08)",
+  text: {
+    primary: "#f8fbff",
+    secondary: "rgba(248, 251, 255, 0.7)"
+  }
+};
+
+export const radii = {
+  glass: 24
+};
+
+export const shadows = {
+  glow: {
+    blue: "0 0 30px rgba(0, 247, 255, 0.3)",
+    purple: "0 0 30px rgba(160, 32, 240, 0.3)",
+    teal: "0 0 30px rgba(0, 255, 209, 0.3)"
+  }
+};
+
+export const timing = {
+  tap: 150,
+  transition: 300
+};
+
+export const fonts = {
+  heading: "SpaceGrotesk_700Bold",
+  body: "Inter_400Regular"
+};
+
+export const moduleAccents: Record<string, string> = {
+  kor: colors.neon.blue,
+  stryke: colors.neon.purple,
+  skrybe: colors.neon.teal,
+  zone: "#ff4ecd",
+  lyfe: "#7cffb8",
+  tree: "#8a5cff",
+  board: "#00d4ff",
+  shop: "#ffad42",
+  vyra: "#ff6ff2"
+};

--- a/vyral/tsconfig.json
+++ b/vyral/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["nativewind/types"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the Expo Router application shell with Supabase, React Query, and theme providers
- build shared neon-glass UI primitives, Zustand user store, and module accent tokens for the cyber aesthetic
- implement onboarding, authentication, and Kor/Stryke/Skrybe/Zone/Lyfe/Tree/Board/Shop/Vyra screens with Supabase-powered data hooks
- add Supabase schema & seed scripts plus a README detailing setup for the monorepo

## Testing
- not run (pnpm dependencies not installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df23d497d08321a06b7845f750909f