### PR TITLE
Add focus session logging with Supabase history

### DIFF
--- a/docs/focus-sessions.md
+++ b/docs/focus-sessions.md
@@ -1,0 +1,22 @@
+# Focus sessions
+
+## Data model
+
+Focus blocks completed from the Zone screen are stored in the `focus_sessions` table inside Supabase. The schema lives in [`supabase/schema.sql`](../supabase/schema.sql) and is kept in source control so the table can be provisioned alongside the rest of the backend objects.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `uuid` | Primary key generated via `uuid_generate_v4()`. |
+| `user_id` | `uuid` | References `users.id`; cascades on delete so a profile wipe removes the history. |
+| `duration_seconds` | `int` | Actual focus time captured (not just the preset). Partial runs log the elapsed seconds before cancellation. |
+| `earned_xp` | `int` | XP rewarded for the block. Calculated client-side as 5 XP per rounded focus minute with a 5 XP floor once a full minute has elapsed. Shorter runs record `0`. |
+| `was_cancelled` | `boolean` | Indicates whether the run ended early via reset/cancel. Defaults to `false`. |
+| `completed_at` | `timestamptz` | Timestamp of when the run was saved. Defaults to `now()`. |
+
+An index on `(user_id, completed_at desc)` accelerates the "recent sessions" lookups used on the Zone screen and any streak calculations.
+
+## XP automation
+
+When the Zone timer reaches zero—or when the user manually resets after making progress—the app inserts a row into `focus_sessions` and awards XP through the shared helper in [`vyral/lib/xp.ts`](../vyral/lib/xp.ts). The helper reads the latest XP value, adds the earned amount, persists it in Supabase, and synchronises the local store so the UI reflects the new total immediately.
+
+The Zone UI treats the latest 10 sessions as the active window for analytics (current streak, minutes logged, XP captured). Alerts confirm when a block has been saved, and partial blocks are marked as "Saved early" in the feed. No push notifications or timed reminders are wired to focus sessions yet; the automation begins and ends with saving the run and applying the XP bonus.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -62,3 +62,14 @@ create table if not exists customizations (
   avatar_url text,
   created_at timestamptz default now()
 );
+
+create table if not exists focus_sessions (
+  id uuid primary key default uuid_generate_v4(),
+  user_id uuid references users(id) on delete cascade not null,
+  duration_seconds int not null,
+  earned_xp int not null,
+  was_cancelled boolean default false,
+  completed_at timestamptz default now()
+);
+
+create index if not exists focus_sessions_user_completed_idx on focus_sessions(user_id, completed_at desc);

--- a/vyral/app/zone/index.tsx
+++ b/vyral/app/zone/index.tsx
@@ -1,15 +1,106 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { View, Text, ScrollView } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { View, Text, ScrollView, Alert } from "react-native";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/Button";
 import { ProgressRing } from "@/components/Progress";
 import { moduleAccents } from "@/theme/tokens";
+import { useSupabase } from "@/lib/supabase";
+import { useUserStore } from "@/store/useUserStore";
+import { awardXp, calculateFocusSessionXp } from "@/lib/xp";
 
 const focusDurations = [15, 25, 45];
 
+type FocusSession = {
+  id: string;
+  duration_seconds: number;
+  earned_xp: number;
+  was_cancelled: boolean;
+  completed_at: string;
+};
+
 const ZoneScreen: React.FC = () => {
+  const { client, session } = useSupabase();
+  const queryClient = useQueryClient();
+  const profile = useUserStore((state) => state.profile);
   const [selectedDuration, setSelectedDuration] = useState(25);
   const [secondsLeft, setSecondsLeft] = useState(selectedDuration * 60);
   const [active, setActive] = useState(false);
+  const plannedSecondsRef = useRef(selectedDuration * 60);
+
+  const { data: recentSessions, isLoading: sessionsLoading } = useQuery<FocusSession[]>({
+    queryKey: ["focus_sessions", session?.user.id],
+    queryFn: async () => {
+      const { data, error } = await client
+        .from("focus_sessions")
+        .select("id, duration_seconds, earned_xp, was_cancelled, completed_at")
+        .eq("user_id", session!.user.id)
+        .order("completed_at", { ascending: false })
+        .limit(10);
+      if (error) throw error;
+      return data;
+    },
+    enabled: Boolean(session)
+  });
+
+  const logSessionMutation = useMutation({
+    mutationFn: async ({ durationSeconds, cancelled }: { durationSeconds: number; cancelled: boolean }) => {
+      if (!session) throw new Error("Not authenticated");
+
+      const earnedXp = calculateFocusSessionXp(durationSeconds);
+      const { data, error } = await client
+        .from("focus_sessions")
+        .insert({
+          user_id: session.user.id,
+          duration_seconds: durationSeconds,
+          earned_xp: earnedXp,
+          was_cancelled: cancelled
+        })
+        .select("id, duration_seconds, earned_xp, was_cancelled, completed_at")
+        .single();
+
+      if (error) throw error;
+
+      if (earnedXp > 0) {
+        await awardXp(client, session.user.id, earnedXp);
+      }
+
+      return data as FocusSession;
+    },
+    onSuccess: async (data, variables) => {
+      await queryClient.invalidateQueries({ queryKey: ["focus_sessions", session?.user.id] });
+
+      if (!data) return;
+
+      const durationText =
+        data.duration_seconds >= 60
+          ? `${Math.round(data.duration_seconds / 60)} minute${
+              Math.round(data.duration_seconds / 60) === 1 ? "" : "s"
+            }`
+          : `${data.duration_seconds} second${data.duration_seconds === 1 ? "" : "s"}`;
+      const xpMessage = data.earned_xp > 0 ? ` • +${data.earned_xp} XP` : "";
+
+      if (variables.cancelled) {
+        Alert.alert("Session saved", `Logged ${durationText}${xpMessage}.`);
+      } else {
+        Alert.alert("Focus complete", `Logged ${durationText}${xpMessage}.`);
+      }
+    },
+    onError: (error) => {
+      Alert.alert("Session not saved", error.message);
+    }
+  });
+
+  const finalizeSession = useCallback(
+    (elapsedSeconds: number, cancelled: boolean) => {
+      if (!session) return;
+
+      const sanitizedSeconds = Math.max(0, Math.round(elapsedSeconds));
+      if (sanitizedSeconds === 0) return;
+
+      logSessionMutation.mutate({ durationSeconds: sanitizedSeconds, cancelled });
+    },
+    [logSessionMutation, session]
+  );
 
   useEffect(() => {
     if (!active) return;
@@ -20,30 +111,116 @@ const ZoneScreen: React.FC = () => {
   }, [active]);
 
   useEffect(() => {
-    if (secondsLeft === 0 && active) {
-      setActive(false);
+    if (!active || secondsLeft > 0) {
+      return;
     }
-  }, [secondsLeft, active]);
+
+    finalizeSession(plannedSecondsRef.current, false);
+    setActive(false);
+    plannedSecondsRef.current = selectedDuration * 60;
+    setSecondsLeft(selectedDuration * 60);
+  }, [secondsLeft, active, finalizeSession, selectedDuration]);
 
   const progress = useMemo(() => secondsLeft / (selectedDuration * 60), [secondsLeft, selectedDuration]);
 
   const toggleTimer = () => {
+    if (active) {
+      setActive(false);
+      return;
+    }
+
     if (secondsLeft === 0) {
       setSecondsLeft(selectedDuration * 60);
+      plannedSecondsRef.current = selectedDuration * 60;
+    } else if (secondsLeft === selectedDuration * 60) {
+      plannedSecondsRef.current = selectedDuration * 60;
     }
-    setActive((prev) => !prev);
+    setActive(true);
   };
 
   const resetTimer = () => {
+    if (session && (active || secondsLeft < plannedSecondsRef.current)) {
+      const elapsedSeconds = plannedSecondsRef.current - secondsLeft;
+      finalizeSession(elapsedSeconds, true);
+    }
     setActive(false);
     setSecondsLeft(selectedDuration * 60);
+    plannedSecondsRef.current = selectedDuration * 60;
   };
 
   const onSelect = (minutes: number) => {
     setSelectedDuration(minutes);
     setSecondsLeft(minutes * 60);
     setActive(false);
+    plannedSecondsRef.current = minutes * 60;
   };
+
+  const formatSessionTimestamp = useCallback((iso: string) => {
+    const date = new Date(iso);
+    try {
+      const dateText = date.toLocaleDateString();
+      const timeText = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+      return `${dateText} • ${timeText}`;
+    } catch (error) {
+      return date.toISOString().replace("T", " ").slice(0, 16);
+    }
+  }, []);
+
+  const totalMinutes = useMemo(() => {
+    if (!recentSessions?.length) return 0;
+    return Math.round(recentSessions.reduce((acc, session) => acc + session.duration_seconds, 0) / 60);
+  }, [recentSessions]);
+
+  const totalXp = useMemo(() => {
+    if (!recentSessions?.length) return 0;
+    return recentSessions.reduce((acc, session) => acc + session.earned_xp, 0);
+  }, [recentSessions]);
+
+  const streakCount = useMemo(() => {
+    if (!recentSessions?.length) return 0;
+
+    const uniqueDays = Array.from(
+      new Set(
+        recentSessions.map((session) => new Date(session.completed_at).toISOString().slice(0, 10))
+      )
+    ).sort((a, b) => (a > b ? -1 : 1));
+
+    let streak = 0;
+    let expectedTime = (() => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      return today.getTime();
+    })();
+
+    for (const dayKey of uniqueDays) {
+      const dayDate = new Date(dayKey);
+      dayDate.setHours(0, 0, 0, 0);
+      const dayTime = dayDate.getTime();
+      const diffDays = Math.round((expectedTime - dayTime) / 86400000);
+
+      if (diffDays === 0) {
+        streak += 1;
+        expectedTime = dayTime - 86400000;
+      } else if (diffDays === 1 && streak === 0) {
+        streak += 1;
+        expectedTime = dayTime - 86400000;
+      } else {
+        break;
+      }
+    }
+
+    return streak;
+  }, [recentSessions]);
+
+  if (!session) {
+    return (
+      <View className="flex-1 items-center justify-center px-8">
+        <Text className="text-center text-lg text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+          Sign in to log focus sessions and earn XP.
+        </Text>
+      </View>
+    );
+  }
 
   const minutes = Math.floor(secondsLeft / 60)
     .toString()
@@ -58,7 +235,9 @@ const ZoneScreen: React.FC = () => {
         Enter the Zone
       </Text>
       <Text className="mt-2 text-base text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
-        Pulse into deep focus with neon ambience.
+        {profile?.username
+          ? `${profile.username}, your neon sanctuary is ready.`
+          : "Pulse into deep focus with neon ambience."}
       </Text>
       <View className="mt-10 items-center">
         <ProgressRing progress={progress} label={`${minutes}:${seconds}`} accentColor={moduleAccents.zone} />
@@ -84,6 +263,87 @@ const ZoneScreen: React.FC = () => {
           />
         </View>
         <Button label="Reset" onPress={resetTimer} variant="secondary" />
+        {logSessionMutation.isPending && (
+          <Text className="mt-4 text-center text-xs text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+            Saving your focus run...
+          </Text>
+        )}
+      </View>
+      <View className="mt-12 rounded-3xl border border-white/10 bg-white/5 p-5">
+        <Text className="text-lg text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+          Focus stats (last 10 sessions)
+        </Text>
+        <View className="mt-4" style={{ rowGap: 12 }}>
+          <View className="flex-row justify-between">
+            <Text className="text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+              Current streak
+            </Text>
+            <Text className="text-sm text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+              {streakCount} day{streakCount === 1 ? "" : "s"}
+            </Text>
+          </View>
+          <View className="flex-row justify-between">
+            <Text className="text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+              Minutes logged
+            </Text>
+            <Text className="text-sm text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+              {totalMinutes}
+            </Text>
+          </View>
+          <View className="flex-row justify-between">
+            <Text className="text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+              XP captured
+            </Text>
+            <Text className="text-sm text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+              {totalXp}
+            </Text>
+          </View>
+        </View>
+      </View>
+      <View className="mt-10">
+        <Text className="text-lg text-white" style={{ fontFamily: "SpaceGrotesk_500Medium" }}>
+          Recent sessions
+        </Text>
+        {sessionsLoading ? (
+          <Text className="mt-3 text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+            Loading your focus history...
+          </Text>
+        ) : recentSessions?.length ? (
+          <View className="mt-4" style={{ rowGap: 12 }}>
+            {recentSessions.map((sessionItem) => {
+              const durationLabel =
+                sessionItem.duration_seconds >= 60
+                  ? `${Math.round(sessionItem.duration_seconds / 60)} minute${
+                      Math.round(sessionItem.duration_seconds / 60) === 1 ? "" : "s"
+                    }`
+                  : `${sessionItem.duration_seconds} second${
+                      sessionItem.duration_seconds === 1 ? "" : "s"
+                    }`;
+              return (
+                <View
+                  key={sessionItem.id}
+                  className="rounded-3xl border border-white/10 bg-white/5 p-4"
+                >
+                  <Text className="text-base text-white" style={{ fontFamily: "Inter_600SemiBold" }}>
+                    {durationLabel} • +{sessionItem.earned_xp} XP
+                  </Text>
+                  <Text className="mt-1 text-xs text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+                    {formatSessionTimestamp(sessionItem.completed_at)}
+                  </Text>
+                  {sessionItem.was_cancelled && (
+                    <Text className="mt-1 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
+                      Saved early
+                    </Text>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        ) : (
+          <Text className="mt-3 text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+            Start a focus block to build your streak and earn XP.
+          </Text>
+        )}
       </View>
     </ScrollView>
   );

--- a/vyral/lib/xp.ts
+++ b/vyral/lib/xp.ts
@@ -1,0 +1,62 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+
+import { useUserStore } from "@/store/useUserStore";
+
+export const FOCUS_XP_PER_MINUTE = 5;
+export const MINIMUM_FOCUS_XP = 5;
+
+export const calculateFocusSessionXp = (durationSeconds: number): number => {
+  if (durationSeconds <= 0) {
+    return 0;
+  }
+
+  if (durationSeconds < 60) {
+    return 0;
+  }
+
+  const minutes = Math.round(durationSeconds / 60);
+  if (minutes <= 0) {
+    return 0;
+  }
+
+  return Math.max(MINIMUM_FOCUS_XP, minutes * FOCUS_XP_PER_MINUTE);
+};
+
+export const awardXp = async (
+  client: SupabaseClient,
+  userId: string,
+  xpToAdd: number
+): Promise<number> => {
+  if (xpToAdd <= 0) {
+    return useUserStore.getState().profile?.xp ?? 0;
+  }
+
+  const { data: current, error: fetchError } = await client
+    .from("users")
+    .select("xp")
+    .eq("id", userId)
+    .single();
+
+  if (fetchError) {
+    throw fetchError;
+  }
+
+  const currentXp = current?.xp ?? 0;
+  const nextXp = currentXp + xpToAdd;
+
+  const { data: updated, error: updateError } = await client
+    .from("users")
+    .update({ xp: nextXp })
+    .eq("id", userId)
+    .select("xp")
+    .single();
+
+  if (updateError) {
+    throw updateError;
+  }
+
+  const resolvedXp = updated?.xp ?? nextXp;
+  useUserStore.getState().updateXP(resolvedXp);
+
+  return resolvedXp;
+};


### PR DESCRIPTION
## Summary
- add a Supabase `focus_sessions` table and supporting index for focus tracking
- log Zone timer completions and early resets through React Query while awarding XP via a shared helper
- document the focus session data model and XP automation for reference

## Testing
- pnpm lint *(fails: proxy prevents downloading pnpm 8.15.4)*

------
https://chatgpt.com/codex/tasks/task_e_68e35d3167988321b97b6bb063b4d944