### PR TITLE
feat: add AI summaries for Skrybe entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,32 @@ EXPO_PUBLIC_SUPABASE_URL=your-url
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 ```
 
+### AI Summaries
+
+The Skrybe module can generate AI summaries for each journal entry via a Supabase Edge Function.
+
+1. Provision the secrets the function needs in your Supabase project:
+
+   ```bash
+   supabase secrets set OPENAI_API_KEY=sk-... \
+     SUPABASE_URL=https://your-project.supabase.co \
+     SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+   ```
+
+2. Deploy the edge function:
+
+   ```bash
+   supabase functions deploy summarize-entry --project-ref <project-ref>
+   ```
+
+3. Call the function locally (optional) with the Supabase CLI to verify connectivity:
+
+   ```bash
+   supabase functions invoke summarize-entry --no-verify-jwt --body '{"entryId":"<uuid>"}'
+   ```
+
+The edge function reads the entry content, requests a concise summary from your configured LLM provider (OpenAI by default), stores it back into the `entries.summary` column, and returns the generated text to the client.
+
 ### Database
 
 Run the provided SQL to bootstrap the Supabase backend.
@@ -41,6 +67,12 @@ Run the provided SQL to bootstrap the Supabase backend.
 ```bash
 supabase db push --file supabase/schema.sql
 supabase db push --file supabase/seed.sql
+```
+
+Run the automated checks (including the summary service mock tests):
+
+```bash
+pnpm test
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "lint": "pnpm --filter vyral lint",
     "typecheck": "pnpm --filter vyral typecheck",
-    "start": "pnpm --filter vyral start"
+    "start": "pnpm --filter vyral start",
+    "test": "TS_NODE_PROJECT=vyral/tsconfig.json node --loader ts-node/esm --test tests/invokeSummarizeEntry.test.ts"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2"
   }
 }

--- a/supabase/functions/summarize-entry/index.ts
+++ b/supabase/functions/summarize-entry/index.ts
@@ -1,0 +1,153 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.7";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.warn("Missing Supabase configuration for summarize-entry edge function");
+}
+
+const supabase = SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+  : undefined;
+
+type SummarizePayload = {
+  entryId?: string;
+};
+
+type OpenAIChatResponse = {
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+};
+
+serve(async (request) => {
+  if (request.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  if (!supabase) {
+    return new Response(JSON.stringify({ error: "Supabase client not configured" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  if (!OPENAI_API_KEY) {
+    return new Response(JSON.stringify({ error: "Missing OPENAI_API_KEY" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  let payload: SummarizePayload;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.error("Failed to parse request payload", error);
+    return new Response(JSON.stringify({ error: "Invalid JSON payload" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  const entryId = payload.entryId;
+  if (!entryId) {
+    return new Response(JSON.stringify({ error: "entryId is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  const { data: entry, error: entryError } = await supabase
+    .from("entries")
+    .select("id, content, user_id")
+    .eq("id", entryId)
+    .single();
+
+  if (entryError || !entry) {
+    console.error("Unable to load entry", entryError);
+    return new Response(JSON.stringify({ error: "Entry not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  const prompt = `Summarize this journal entry written by the user in 2 concise sentences. Highlight the main themes and tone. Entry: \n${entry.content ?? ""}`;
+
+  let summary: string | undefined;
+  try {
+    const aiResponse = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [
+          {
+            role: "system",
+            content: "You are an assistant that summarizes personal journal entries in a warm, encouraging voice."
+          },
+          {
+            role: "user",
+            content: prompt
+          }
+        ],
+        temperature: 0.4,
+        max_tokens: 200
+      })
+    });
+
+    if (!aiResponse.ok) {
+      const errorText = await aiResponse.text();
+      console.error("OpenAI API error", errorText);
+      return new Response(JSON.stringify({ error: "Failed to generate summary" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const completion = (await aiResponse.json()) as OpenAIChatResponse;
+    summary = completion.choices?.[0]?.message?.content?.trim();
+  } catch (error) {
+    console.error("OpenAI request failed", error);
+    return new Response(JSON.stringify({ error: "AI request failed" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  if (!summary) {
+    return new Response(JSON.stringify({ error: "Summary was empty" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  const { error: updateError } = await supabase
+    .from("entries")
+    .update({ summary })
+    .eq("id", entryId);
+
+  if (updateError) {
+    console.error("Failed to persist summary", updateError);
+    return new Response(JSON.stringify({ error: "Failed to store summary" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  return new Response(JSON.stringify({ summary }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" }
+  });
+});

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -36,6 +36,7 @@ create table if not exists entries (
   id uuid primary key default uuid_generate_v4(),
   user_id uuid references users(id) on delete cascade not null,
   content text,
+  summary text,
   created_at timestamptz default now()
 );
 

--- a/tests/invokeSummarizeEntry.test.ts
+++ b/tests/invokeSummarizeEntry.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { invokeSummarizeEntry, SummarizeEntryError } from "../vyral/lib/summaries";
+
+type InvokeArgs = Parameters<typeof invokeSummarizeEntry>;
+
+test("invokeSummarizeEntry returns the summary when provided", async () => {
+  const mockClient = {
+    functions: {
+      invoke: async () => ({
+        data: { summary: "A short recap." },
+        error: null
+      })
+    }
+  } as unknown as InvokeArgs[0];
+
+  const summary = await invokeSummarizeEntry(mockClient, "entry-id");
+  assert.equal(summary, "A short recap.");
+});
+
+test("invokeSummarizeEntry throws when Supabase returns an error", async () => {
+  const mockClient = {
+    functions: {
+      invoke: async () => ({
+        data: null,
+        error: { message: "Function failure" }
+      })
+    }
+  } as unknown as InvokeArgs[0];
+
+  await assert.rejects(() => invokeSummarizeEntry(mockClient, "entry-id"), (error) => {
+    assert.ok(error instanceof SummarizeEntryError);
+    assert.equal(error.message, "Function failure");
+    return true;
+  });
+});
+
+test("invokeSummarizeEntry throws when summary is missing", async () => {
+  const mockClient = {
+    functions: {
+      invoke: async () => ({
+        data: {},
+        error: null
+      })
+    }
+  } as unknown as InvokeArgs[0];
+
+  await assert.rejects(() => invokeSummarizeEntry(mockClient, "entry-id"), (error) => {
+    assert.ok(error instanceof SummarizeEntryError);
+    assert.equal(error.message, "Summary not returned");
+    return true;
+  });
+});

--- a/vyral/app/skrybe/index.tsx
+++ b/vyral/app/skrybe/index.tsx
@@ -1,22 +1,31 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Text, ScrollView, TextInput, Alert } from "react-native";
 import { useSupabase } from "@/lib/supabase";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { moduleAccents } from "@/theme/tokens";
+import { invokeSummarizeEntry, SummarizeEntryError } from "@/lib/summaries";
+
+type Entry = {
+  id: string;
+  content: string;
+  created_at: string;
+  summary: string | null;
+};
 
 const SkrybeScreen: React.FC = () => {
   const { client, session } = useSupabase();
   const queryClient = useQueryClient();
   const [content, setContent] = useState("");
+  const [activeEntryId, setActiveEntryId] = useState<string | null>(null);
 
   const entriesQuery = useQuery({
     queryKey: ["entries", session?.user.id],
     queryFn: async () => {
       const { data, error } = await client
         .from("entries")
-        .select("id, content, created_at")
+        .select("id, content, created_at, summary")
         .eq("user_id", session!.user.id)
         .order("created_at", { ascending: false });
       if (error) throw error;
@@ -24,6 +33,33 @@ const SkrybeScreen: React.FC = () => {
     },
     enabled: Boolean(session)
   });
+
+  const summarizeEntryMutation = useMutation({
+    mutationFn: async (entryId: string) => {
+      setActiveEntryId(entryId);
+      return await invokeSummarizeEntry(client, entryId);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["entries", session?.user.id] });
+    },
+    onError: (error) => {
+      if (error instanceof SummarizeEntryError || error instanceof Error) {
+        Alert.alert("Unable to summarize", error.message);
+      } else {
+        Alert.alert("Unable to summarize", "Please try again later.");
+      }
+    },
+    onSettled: () => setActiveEntryId(null)
+  });
+
+  const summarizeEntryState = useMemo(() => {
+    return {
+      isLoading: summarizeEntryMutation.isPending,
+      activeId: activeEntryId,
+      lastVariables: summarizeEntryMutation.variables,
+      error: summarizeEntryMutation.error
+    };
+  }, [summarizeEntryMutation.error, summarizeEntryMutation.isPending, summarizeEntryMutation.variables, activeEntryId]);
 
   const createEntry = useMutation({
     mutationFn: async () => {
@@ -85,18 +121,53 @@ const SkrybeScreen: React.FC = () => {
           disabled={createEntry.isPending}
         />
         <Text className="mt-4 text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
-          AI synthesis arriving soon.
+          Use the AI summary below each entry to quickly recap your thoughts.
         </Text>
       </Card>
       <View className="mt-10" style={{ rowGap: 16 }}>
-        {entriesQuery.data?.map((entry) => (
-          <Card key={entry.id} accentColor={moduleAccents.skrybe} className="p-4">
+        {(entriesQuery.data as Entry[] | undefined)?.map((entry) => (
+          <Card key={entry.id} accentColor={moduleAccents.skrybe} className="p-4" style={{ rowGap: 12 }}>
             <Text className="text-xs text-white/50" style={{ fontFamily: "Inter_400Regular" }}>
               {new Date(entry.created_at).toLocaleString()}
             </Text>
             <Text className="mt-2 text-base text-white" style={{ fontFamily: "Inter_400Regular" }}>
               {entry.content}
             </Text>
+            <View style={{ rowGap: 8 }}>
+              <Button
+                label={
+                  summarizeEntryState.isLoading && summarizeEntryState.activeId === entry.id
+                    ? "Summarizing..."
+                    : entry.summary
+                      ? "Refresh summary"
+                      : "Generate summary"
+                }
+                onPress={() => summarizeEntryMutation.mutate(entry.id)}
+                accentColor={moduleAccents.skrybe}
+                disabled={summarizeEntryState.isLoading && summarizeEntryState.activeId === entry.id}
+              />
+              <View className="rounded-md bg-white/5 p-3">
+                {summarizeEntryState.isLoading && summarizeEntryState.activeId === entry.id ? (
+                  <Text className="text-sm text-white/70" style={{ fontFamily: "Inter_400Regular" }}>
+                    Crafting your recap...
+                  </Text>
+                ) : summarizeEntryMutation.isError && summarizeEntryState.lastVariables === entry.id ? (
+                  <Text className="text-sm text-red-300" style={{ fontFamily: "Inter_400Regular" }}>
+                    {summarizeEntryMutation.error instanceof Error
+                      ? summarizeEntryMutation.error.message
+                      : "Something went wrong."}
+                  </Text>
+                ) : entry.summary ? (
+                  <Text className="text-sm text-white" style={{ fontFamily: "Inter_400Regular" }}>
+                    {entry.summary}
+                  </Text>
+                ) : (
+                  <Text className="text-sm text-white/60" style={{ fontFamily: "Inter_400Regular" }}>
+                    No summary yet. Generate one to see the highlights.
+                  </Text>
+                )}
+              </View>
+            </View>
           </Card>
         ))}
       </View>

--- a/vyral/lib/summaries.ts
+++ b/vyral/lib/summaries.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export class SummarizeEntryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SummarizeEntryError";
+  }
+}
+
+type SummarizeEntryResponse = {
+  summary?: string | null;
+};
+
+type SummarizeEntryInvokeResult = {
+  data: SummarizeEntryResponse | null;
+  error: { message: string } | null;
+};
+
+export const invokeSummarizeEntry = async (
+  client: SupabaseClient,
+  entryId: string
+): Promise<string> => {
+  const { data, error } = (await client.functions.invoke<SummarizeEntryResponse>("summarize-entry", {
+    body: { entryId }
+  })) as SummarizeEntryInvokeResult;
+
+  if (error) {
+    throw new SummarizeEntryError(error.message);
+  }
+
+  if (!data?.summary) {
+    throw new SummarizeEntryError("Summary not returned");
+  }
+
+  return data.summary;
+};


### PR DESCRIPTION
## Summary
- add a Supabase Edge Function that calls OpenAI to summarize journal entries and persists the AI output
- extend the Skrybe screen with a summary mutation, loading/error UI, and display of stored AI recaps
- document configuration for the new service, add a summary column to entries, and include a unit test for the client helper

## Testing
- pnpm install *(fails: registry blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35d341c888321808261f936d50430